### PR TITLE
chore: add lefthook hooks and CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+
+permissions:
+    contents: read
+
+concurrency:
+    group: ci-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Install pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10.8.0
+                  run_install: false
+
+            - name: Install Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: .nvmrc
+                  cache: pnpm
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Lint
+              run: pnpm run lint
+
+            - name: Check formatting
+              run: pnpm run format:check
+
+            - name: Build
+              run: pnpm run build

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Git hooks managed by lefthook — https://lefthook.dev
+# Installed automatically via the "prepare" script on `pnpm install`.
+
+pre-commit:
+  parallel: true
+  commands:
+    format:
+      glob: "src/*.{ts,js}"
+      run: pnpm exec prettier --write {staged_files}
+      stage_fixed: true
+    lint:
+      glob: "src/*.ts"
+      run: pnpm exec eslint {staged_files}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
     "version": "node version-bump.mjs && git add manifest.json versions.json",
     "lint": "eslint src --ext .ts,.js",
-    "format": "prettier --write src"
+    "lint:fix": "eslint src --ext .ts,.js --fix",
+    "format": "prettier --write src",
+    "format:check": "prettier --check src",
+    "typecheck": "tsc -noEmit -skipLibCheck",
+    "prepare": "lefthook install"
   },
   "keywords": [],
   "author": "",
@@ -18,6 +22,7 @@
     "@types/node": "^16.11.6",
     "esbuild": "0.17.3",
     "eslint": "^9.39.4",
+    "lefthook": "^2.1.9",
     "obsidian": "latest",
     "prettier": "^3.5.3",
     "tslib": "2.4.0",
@@ -25,6 +30,10 @@
     "typescript-eslint": "^8.61.0"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "lefthook"
+    ],
     "overrides": {
       "flatted": ">=3.4.2"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
+      lefthook:
+        specifier: ^2.1.9
+        version: 2.1.9
       obsidian:
         specifier: latest
         version: 1.13.1(@codemirror/state@6.5.0)(@codemirror/view@6.38.6)
@@ -540,6 +543,60 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  lefthook-darwin-arm64@2.1.9:
+    resolution: {integrity: sha512-119HryNcvr4nqn0wUIrNPgpMEPn9yMQzEcW/lezRsnb56PCJriJB92+MCySPVcWDxJnZef7o0T3jdnPNiSH7Qg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.9:
+    resolution: {integrity: sha512-dwo5Tke2XcQCM56DGHgFKBfRbJIL6xs2wZ0zG1TUVZgl4t4mQUt6LiZ4V/ZQfYHTZF9qywvXoIlR5N35qOaiVQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.9:
+    resolution: {integrity: sha512-+09PVap6nl6xsaHch5JLtq7WvIR++U1Q2MzA2ai0M4uB/VP3AqrvKqHw6+9hjyKnIH+HHL83uqi77EAY+LaxLA==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.9:
+    resolution: {integrity: sha512-8XresjKIYpkE9ARgCtBEZgJZxAU3T4MIqzj4zNy15XRT59I1Us+QdqXTNm+pkZ41Yd2X/nxs2Pkvbq3NWWlIGw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.9:
+    resolution: {integrity: sha512-1oNIQfwrPe6rgU2KcDM3aF6+hpZDCKx1TmawQKpXUY5gVsbZ7MqX0Sk/1lnnWxqPm+kQQ5f6J2dpFWd+4xH8jg==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.9:
+    resolution: {integrity: sha512-fT+7Q+BJyGp+CslFQkNXmdFRgyVXsPHPi9NAsDX0a6QOyNnoORByAsvx6zeAKuF5rL3BBgNfho1/v2RuGxGy9w==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.9:
+    resolution: {integrity: sha512-4bVuafBk3dddVNo0+3hMbjcJs4mqYAstxpPMmX2ufkudSTYFNIhWoqwuGVQV/SS/xdcOKJAldW4qayAzed2ysw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.9:
+    resolution: {integrity: sha512-PmPoMmLP/wQQWcQ9u2YH86bTZ3UCfBsxuEmVTEyPU2U8R1qSTp5r/Gs3G8cN5Mxo91XB9oBERtF1n+xD3W6aVA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.9:
+    resolution: {integrity: sha512-KphfkBKmwBnmolyrdhIl3lrBaOyTcCgXBT2AB/9OHnEXhOLvv5uTCUkrD4YRAxXPtFKq6UvnapIeoL3GZq0bdA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.9:
+    resolution: {integrity: sha512-2qlUtkJHZ3MyUxgV5XTEmcrIoNZA07iwaquoswAcqv/1MeBFXlD+O+koFRfrzWng2O5WYEbpJnd8tvaYnV8fTA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.9:
+    resolution: {integrity: sha512-bwDaIOViTktE8kJLf9jP0p+H2/RDTlFFlc43Am2YgUsX22hI6Sq4RbzsrecwzY5y+MHTipOH7WsmWSEniePHWQ==}
+    hasBin: true
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -1164,6 +1221,49 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  lefthook-darwin-arm64@2.1.9:
+    optional: true
+
+  lefthook-darwin-x64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.9:
+    optional: true
+
+  lefthook-linux-arm64@2.1.9:
+    optional: true
+
+  lefthook-linux-x64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.9:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.9:
+    optional: true
+
+  lefthook-windows-arm64@2.1.9:
+    optional: true
+
+  lefthook-windows-x64@2.1.9:
+    optional: true
+
+  lefthook@2.1.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.9
+      lefthook-darwin-x64: 2.1.9
+      lefthook-freebsd-arm64: 2.1.9
+      lefthook-freebsd-x64: 2.1.9
+      lefthook-linux-arm64: 2.1.9
+      lefthook-linux-x64: 2.1.9
+      lefthook-openbsd-arm64: 2.1.9
+      lefthook-openbsd-x64: 2.1.9
+      lefthook-windows-arm64: 2.1.9
+      lefthook-windows-x64: 2.1.9
 
   levn@0.4.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,9 @@
+# Approve dependency build scripts (pnpm >=11 reads `allowBuilds` here;
+# older pnpm/CI reads `pnpm.onlyBuiltDependencies` in package.json).
+allowBuilds:
+  esbuild: true
+  lefthook: true
+
 # Force a patched flatted (pulled transitively by eslint's file cache).
 # Mirrors the `pnpm.overrides` entry in package.json so the override applies
 # on both pnpm >=10.13/11 (reads here) and older pnpm/CI (reads package.json).

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,14 @@
 import { Plugin, TFile, normalizePath, Notice } from "obsidian";
 
 import FolderThemeSettingTab from "./ui/SettingTab";
-import { FolderThemeSettings, DEFAULT_SETTINGS, ThemeMode, getEffectiveValue, ThemeType, OBSIDIAN_DEFAULT_THEME } from "./settings";
+import {
+    FolderThemeSettings,
+    DEFAULT_SETTINGS,
+    ThemeMode,
+    getEffectiveValue,
+    ThemeType,
+    OBSIDIAN_DEFAULT_THEME,
+} from "./settings";
 
 declare module "obsidian" {
     interface App {
@@ -14,7 +21,7 @@ declare module "obsidian" {
 }
 
 export default class FolderThemePlugin extends Plugin {
-    settings: FolderThemeSettings = DEFAULT_SETTINGS
+    settings: FolderThemeSettings = DEFAULT_SETTINGS;
     userTheme: string | null = null; // To store user's global theme
 
     async onload() {


### PR DESCRIPTION
## Summary
Adds basic git hooks (lefthook) and a CI workflow.

> [!NOTE]
> Stacked on top of #9 (`fix/obsidian-review-feedback`) because this builds on the `pnpm-workspace.yaml` / tooling it introduces, and was tested against that state. Retarget the base to `main` once #9 merges.

## lefthook (`lefthook.yml`)
`pre-commit` (parallel, staged files only):
- **format** — `prettier --write` on `src/*.{ts,js}` (auto-restages fixed files via `stage_fixed`)
- **lint** — `eslint` on `src/*.ts`

Auto-installed through the `prepare` script on `pnpm install`.

## CI (`.github/workflows/ci.yaml`)
Runs on PRs and pushes to `main` (mirrors `release.yaml`: pnpm 10.8.0, Node from `.nvmrc`, pnpm cache; cancels superseded runs).
Steps: `install --frozen-lockfile` → `lint` → `format:check` → `build` (`tsc` + esbuild).

## Supporting changes
- `package.json`: add `lefthook` dep, `lint:fix`/`format:check`/`typecheck`/`prepare` scripts, and `pnpm.onlyBuiltDependencies`.
- `pnpm-workspace.yaml`: `allowBuilds` for esbuild/lefthook — pnpm 11 was hard-erroring on unapproved build scripts, which blocked every `pnpm run`.
- `src/main.ts`: prettier reformat so the new format check is green (different lines than #9's content changes, so no conflict).

## Verification
- pre-commit hook: format + lint pass on a real commit
- `pnpm run lint`, `format:check`, `build`, and `install --frozen-lockfile` all exit 0